### PR TITLE
Refactor: v2beta folder

### DIFF
--- a/v2beta/conf.py
+++ b/v2beta/conf.py
@@ -1,15 +1,17 @@
 from libparse import Loc, Stream, Span, Spanned, Head
-from libparse import Result, Wrong, Error, ErrLevel
+from libparse import Result, Error, ErrLevel
 import sylex_ast as ast
 from typing import Union, Tuple
 from enum import Enum
 from dataclasses import dataclass
 
+
 @dataclass
 class File:
     path: list[str]
     name: str
-    ext: str|None
+    ext: str | None
+
 
 class Label(Enum):
     ROOT = "root"
@@ -18,6 +20,7 @@ class Label(Enum):
     PDF = "pdf"
     FIG = "fig"
 
+
 @dataclass
 class MetaFile:
     file: File
@@ -25,9 +28,11 @@ class MetaFile:
     depend: list[File]
     label: Label
 
+
 @dataclass
 class Feature:
     path: list[str]
+
 
 @dataclass
 class Target:
@@ -37,10 +42,12 @@ class Target:
     root: File
     features: list[Feature]
 
+
 @dataclass
 class Config:
     targets: list[Target]
     errors: list[Tuple[ErrLevel, Error]]
+
 
 # Config checks                             Critical ?
 #  - exist & unique

--- a/v2beta/libparse.py
+++ b/v2beta/libparse.py
@@ -5,9 +5,6 @@ from enum import Enum
 from typing import Any, Callable, Generic, Optional, Tuple, TypeVar, Union
 
 T = TypeVar("T")
-U = TypeVar("U")
-TCo = TypeVar("TCo")
-UCo = TypeVar("UCo")
 
 
 @dataclass
@@ -59,6 +56,8 @@ class Loc:
 
 @dataclass
 class Span:
+    U = TypeVar("U")
+
     start: Loc
     end: Loc
 
@@ -70,7 +69,7 @@ class Span:
     def unit(loc: Loc) -> Span:
         return Span(loc, loc)
 
-    def with_data(self, data: T) -> Spanned[T]:
+    def with_data(self, data: U) -> Spanned[U]:
         return Spanned(data, self)
 
     def until(self, other: Optional[Loc | Span] = None) -> Span:
@@ -87,8 +86,10 @@ class Span:
 
 
 @dataclass
-class Spanned(Generic[TCo]):
-    data: TCo
+class Spanned(Generic[T]):
+    U = TypeVar("U")
+
+    data: T
     span: Span
 
     @staticmethod
@@ -99,7 +100,7 @@ class Spanned(Generic[TCo]):
             span.end = max(span.end, lst[-1].span.end)
         return span
 
-    def map(self: Spanned[TCo], fn: Callable[[TCo], U]) -> Spanned[U]:
+    def map(self, fn: Callable[[T], U]) -> Spanned[U]:
         return Spanned(fn(self.data), self.span)
 
     def __str__(self) -> str:
@@ -144,13 +145,13 @@ class ErrLevel(Enum):
     INFO = 1
 
 
-Result = Union[UCo, Error]
-SpanResult = Result[Spanned[UCo]]
+Result = Union[T, Error]
+SpanResult = Result[Spanned[T]]
 
 
 @dataclass
-class Maybe(Generic[UCo]):
-    data: UCo
+class Maybe(Generic[T]):
+    data: T
     diagnostic: Error
 
 
@@ -172,6 +173,8 @@ class Maybe(Generic[UCo]):
 
 @dataclass
 class Head(Generic[T]):
+    U = TypeVar("U")
+
     _stream: Stream[T]
     _cursor: int
 

--- a/v2beta/libparse.py
+++ b/v2beta/libparse.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from typing import Union, Optional, TypeVar, Generic, Any, Callable, Tuple
 from enum import Enum
+from typing import Any, Callable, Generic, Optional, Tuple, TypeVar, Union
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -16,30 +16,42 @@ class Loc:
     col: int
 
     @staticmethod
-    def max() -> 'Loc':
+    def max() -> "Loc":
         return Loc(1_000_000, 1_000_000)
 
     @staticmethod
-    def min() -> 'Loc':
+    def min() -> "Loc":
         return Loc(-1, -1)
 
-    def newline(self) -> 'Loc':
+    def newline(self) -> "Loc":
         return Loc(self.line + 1, 0)
 
-    def newcol(self) -> 'Loc':
+    def newcol(self) -> "Loc":
         return Loc(self.line, self.col + 1)
 
-    def cmp(self, other: 'Loc') -> int:
-        if self.line < other.line: return -1
-        elif self.line > other.line: return 1
-        elif self.col < other.col: return -1
-        elif self.col > other.col: return 1
-        else: return 0
+    def cmp(self, other: "Loc") -> int:
+        if self.line < other.line:
+            return -1
+        elif self.line > other.line:
+            return 1
+        elif self.col < other.col:
+            return -1
+        elif self.col > other.col:
+            return 1
+        else:
+            return 0
 
-    def __lt__(self, other: 'Loc') -> bool: return self.cmp(other) < 0
-    def __le__(self, other: 'Loc') -> bool: return self.cmp(other) <= 0
-    def __gt__(self, other: 'Loc') -> bool: return self.cmp(other) > 0
-    def __ge__(self, other: 'Loc') -> bool: return self.cmp(other) >= 0
+    def __lt__(self, other: "Loc") -> bool:
+        return self.cmp(other) < 0
+
+    def __le__(self, other: "Loc") -> bool:
+        return self.cmp(other) <= 0
+
+    def __gt__(self, other: "Loc") -> bool:
+        return self.cmp(other) > 0
+
+    def __ge__(self, other: "Loc") -> bool:
+        return self.cmp(other) >= 0
 
     def __str__(self) -> str:
         return f"{self.line}:{self.col}"
@@ -51,17 +63,17 @@ class Span:
     end: Loc
 
     @staticmethod
-    def empty() -> 'Span':
+    def empty() -> "Span":
         return Span(Loc.max(), Loc.min())
 
     @staticmethod
-    def unit(loc: Loc) -> 'Span':
+    def unit(loc: Loc) -> "Span":
         return Span(loc, loc)
 
-    def with_data(self, data: T) -> 'Spanned[T]':
+    def with_data(self, data: T) -> "Spanned[T]":
         return Spanned(data, self)
 
-    def until(self, other: Optional[Union[Loc,'Span']]) -> 'Span':
+    def until(self, other: Optional[Union[Loc, "Span"]]) -> "Span":
         if other is None:
             return self
         elif isinstance(other, Loc):
@@ -79,14 +91,14 @@ class Spanned(Generic[TCo]):
     span: Span
 
     @staticmethod
-    def union(lst: list['Spanned[Any]']) -> Span:
+    def union(lst: list["Spanned[Any]"]) -> Span:
         span = Span.empty()
         if len(lst) > 0:
             span.start = min(span.start, lst[0].span.start)
             span.end = max(span.end, lst[-1].span.end)
         return span
 
-    def map(self: 'Spanned[TCo]', fn: Callable[[TCo], U]) -> 'Spanned[U]':
+    def map(self: "Spanned[TCo]", fn: Callable[[TCo], U]) -> "Spanned[U]":
         return Spanned(fn(self.data), self.span)
 
     def __str__(self) -> str:
@@ -98,7 +110,7 @@ class Stream(Generic[T]):
     data: list[Spanned[T]]
 
     @staticmethod
-    def empty() -> 'Stream[T]':
+    def empty() -> "Stream[T]":
         return Stream([])
 
     def append(self, data: Spanned[T]) -> None:
@@ -110,12 +122,13 @@ class Stream(Generic[T]):
         else:
             return None
 
-    def __getitem__(self, idx: slice) -> 'Stream[T]':
+    def __getitem__(self, idx: slice) -> "Stream[T]":
         return Stream(self.data[idx])
 
 
 BackRef = Tuple[Span, Span]
-ErrExtra = Span|None|BackRef
+ErrExtra = Span | None | BackRef
+
 
 @dataclass
 class Error:
@@ -148,6 +161,8 @@ SpanResult = Result[Spanned[UCo], VCo]
 class Maybe(Generic[UCo]):
     data: UCo
     diagnostic: Error
+
+
 # What's the use-case of Maybe, you may ask ?
 # Consider the grammar a?b
 # If you reab cb then a? matches nothing and b fails to read c
@@ -170,7 +185,7 @@ class Head(Generic[T]):
     _cursor: int
 
     @staticmethod
-    def start(stream: Stream[T]) -> 'Head[T]':
+    def start(stream: Stream[T]) -> "Head[T]":
         return Head(stream, 0)
 
     def bump(self, nb: int = 1) -> None:
@@ -182,13 +197,13 @@ class Head(Generic[T]):
     def peek(self, nb: int = 0) -> Optional[Spanned[T]]:
         return self._peek_absolute(self._cursor + nb)
 
-    def clone(self) -> 'Head[T]':
+    def clone(self) -> "Head[T]":
         return Head(self._stream, self._cursor)
 
-    def commit(self, other: 'Head[T]') -> None:
+    def commit(self, other: "Head[T]") -> None:
         self._cursor = other._cursor
 
-    def until(self, other: Union[int, 'Head[T]', Span, None]) -> Span:
+    def until(self, other: Union[int, "Head[T]", Span, None]) -> Span:
         if other is None:
             span = Span.empty()
         elif isinstance(other, Head):
@@ -199,15 +214,17 @@ class Head(Generic[T]):
             span = self._span_absolute(self._cursor + other)
         return (self.span() or Span.empty()).until(span)
 
-    def sub(self, fn: Callable[['Head[T]'], Result[U, V]]) -> SpanResult[U, V]:
+    def sub(self, fn: Callable[["Head[T]"], Result[U, V]]) -> SpanResult[U, V]:
         print(f"enter {fn.__name__}")
         copy = self.clone()
         res = fn(copy)
-        print(f"function {fn.__name__}\n\tread {res}\n\tbetween {self.span()} and {copy.span()}")
+        print(
+            f"function {fn.__name__}\n\tread {res}\n\tbetween {self.span()} and {copy.span()}"
+        )
         if isinstance(res, Wrong):
             return res
         else:
-            span = Spanned.union(self._stream[self._cursor:copy._cursor].data)
+            span = Spanned.union(self._stream[self._cursor : copy._cursor].data)
             self.commit(copy)
             return span.with_data(res)
 
@@ -222,5 +239,3 @@ class Head(Generic[T]):
 
     def err(self, kind: str, msg: str, span: Span) -> Wrong[Error]:
         return Wrong(Error(kind, msg, self.until(span)))
-
-

--- a/v2beta/libparse.py
+++ b/v2beta/libparse.py
@@ -6,10 +6,8 @@ from typing import Any, Callable, Generic, Optional, Tuple, TypeVar, Union
 
 T = TypeVar("T")
 U = TypeVar("U")
-V = TypeVar("V")
 TCo = TypeVar("TCo")
 UCo = TypeVar("UCo")
-VCo = TypeVar("VCo")
 
 
 @dataclass
@@ -75,10 +73,11 @@ class Span:
     def with_data(self, data: T) -> Spanned[T]:
         return Spanned(data, self)
 
-    def until(self, other: Optional[Union[Loc, Span]]) -> Span:
+    def until(self, other: Optional[Loc | Span] = None) -> Span:
         if other is None:
             return self
-        elif isinstance(other, Loc):
+
+        if isinstance(other, Loc):
             return Span(min(other, self.start), max(other, self.end))
         else:
             return Span(min(other.start, self.start), max(other.end, self.end))
@@ -119,10 +118,9 @@ class Stream(Generic[T]):
         self.data.append(data)
 
     def peek(self, idx: int) -> Optional[Spanned[T]]:
-        if idx < len(self.data):
-            return self.data[idx]
-        else:
+        if idx >= len(self.data):
             return None
+        return self.data[idx]
 
     def __getitem__(self, idx: slice) -> Stream[T]:
         return Stream(self.data[idx])
@@ -196,7 +194,7 @@ class Head(Generic[T]):
     def commit(self, other: Head[T]) -> None:
         self._cursor = other._cursor
 
-    def until(self, other: Union[int, Head[T], Span, None]) -> Span:
+    def until(self, other: int | Head[T] | Span | None) -> Span:
         if other is None:
             span = Span.empty()
         elif isinstance(other, Head):

--- a/v2beta/libparse.py
+++ b/v2beta/libparse.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Generic, Optional, Tuple, TypeVar, Union
@@ -16,20 +18,20 @@ class Loc:
     col: int
 
     @staticmethod
-    def max() -> "Loc":
+    def max() -> Loc:
         return Loc(1_000_000, 1_000_000)
 
     @staticmethod
-    def min() -> "Loc":
+    def min() -> Loc:
         return Loc(-1, -1)
 
-    def newline(self) -> "Loc":
+    def newline(self) -> Loc:
         return Loc(self.line + 1, 0)
 
-    def newcol(self) -> "Loc":
+    def newcol(self) -> Loc:
         return Loc(self.line, self.col + 1)
 
-    def cmp(self, other: "Loc") -> int:
+    def cmp(self, other: Loc) -> int:
         if self.line < other.line:
             return -1
         elif self.line > other.line:
@@ -41,16 +43,16 @@ class Loc:
         else:
             return 0
 
-    def __lt__(self, other: "Loc") -> bool:
+    def __lt__(self, other: Loc) -> bool:
         return self.cmp(other) < 0
 
-    def __le__(self, other: "Loc") -> bool:
+    def __le__(self, other: Loc) -> bool:
         return self.cmp(other) <= 0
 
-    def __gt__(self, other: "Loc") -> bool:
+    def __gt__(self, other: Loc) -> bool:
         return self.cmp(other) > 0
 
-    def __ge__(self, other: "Loc") -> bool:
+    def __ge__(self, other: Loc) -> bool:
         return self.cmp(other) >= 0
 
     def __str__(self) -> str:
@@ -63,17 +65,17 @@ class Span:
     end: Loc
 
     @staticmethod
-    def empty() -> "Span":
+    def empty() -> Span:
         return Span(Loc.max(), Loc.min())
 
     @staticmethod
-    def unit(loc: Loc) -> "Span":
+    def unit(loc: Loc) -> Span:
         return Span(loc, loc)
 
-    def with_data(self, data: T) -> "Spanned[T]":
+    def with_data(self, data: T) -> Spanned[T]:
         return Spanned(data, self)
 
-    def until(self, other: Optional[Union[Loc, "Span"]]) -> "Span":
+    def until(self, other: Optional[Union[Loc, Span]]) -> Span:
         if other is None:
             return self
         elif isinstance(other, Loc):
@@ -91,14 +93,14 @@ class Spanned(Generic[TCo]):
     span: Span
 
     @staticmethod
-    def union(lst: list["Spanned[Any]"]) -> Span:
+    def union(lst: list[Spanned[Any]]) -> Span:
         span = Span.empty()
         if len(lst) > 0:
             span.start = min(span.start, lst[0].span.start)
             span.end = max(span.end, lst[-1].span.end)
         return span
 
-    def map(self: "Spanned[TCo]", fn: Callable[[TCo], U]) -> "Spanned[U]":
+    def map(self: Spanned[TCo], fn: Callable[[TCo], U]) -> Spanned[U]:
         return Spanned(fn(self.data), self.span)
 
     def __str__(self) -> str:
@@ -110,7 +112,7 @@ class Stream(Generic[T]):
     data: list[Spanned[T]]
 
     @staticmethod
-    def empty() -> "Stream[T]":
+    def empty() -> Stream[T]:
         return Stream([])
 
     def append(self, data: Spanned[T]) -> None:
@@ -122,7 +124,7 @@ class Stream(Generic[T]):
         else:
             return None
 
-    def __getitem__(self, idx: slice) -> "Stream[T]":
+    def __getitem__(self, idx: slice) -> Stream[T]:
         return Stream(self.data[idx])
 
 
@@ -185,7 +187,7 @@ class Head(Generic[T]):
     _cursor: int
 
     @staticmethod
-    def start(stream: Stream[T]) -> "Head[T]":
+    def start(stream: Stream[T]) -> Head[T]:
         return Head(stream, 0)
 
     def bump(self, nb: int = 1) -> None:
@@ -197,13 +199,13 @@ class Head(Generic[T]):
     def peek(self, nb: int = 0) -> Optional[Spanned[T]]:
         return self._peek_absolute(self._cursor + nb)
 
-    def clone(self) -> "Head[T]":
+    def clone(self) -> Head[T]:
         return Head(self._stream, self._cursor)
 
-    def commit(self, other: "Head[T]") -> None:
+    def commit(self, other: Head[T]) -> None:
         self._cursor = other._cursor
 
-    def until(self, other: Union[int, "Head[T]", Span, None]) -> Span:
+    def until(self, other: Union[int, Head[T], Span, None]) -> Span:
         if other is None:
             span = Span.empty()
         elif isinstance(other, Head):
@@ -214,7 +216,7 @@ class Head(Generic[T]):
             span = self._span_absolute(self._cursor + other)
         return (self.span() or Span.empty()).until(span)
 
-    def sub(self, fn: Callable[["Head[T]"], Result[U, V]]) -> SpanResult[U, V]:
+    def sub(self, fn: Callable[[Head[T]], Result[U, V]]) -> SpanResult[U, V]:
         print(f"enter {fn.__name__}")
         copy = self.clone()
         res = fn(copy)

--- a/v2beta/libparse.py
+++ b/v2beta/libparse.py
@@ -7,9 +7,9 @@ from typing import Any, Callable, Generic, Optional, Tuple, TypeVar, Union
 T = TypeVar("T")
 U = TypeVar("U")
 V = TypeVar("V")
-TCo = TypeVar("TCo", covariant=True)
-UCo = TypeVar("UCo", covariant=True)
-VCo = TypeVar("VCo", covariant=True)
+TCo = TypeVar("TCo")
+UCo = TypeVar("UCo")
+VCo = TypeVar("VCo")
 
 
 @dataclass

--- a/v2beta/parse.py
+++ b/v2beta/parse.py
@@ -192,7 +192,7 @@ def ast_of_tokens(tokens: Tokens) -> SpanResult[DefList]:
 def parse_deflist(hd: HToken) -> Result[Maybe[DefList]]:
     # DefList := Def *
     start = hd.span()
-    defs: list[Spanned[Def | Target]] = []
+    defs: list[Spanned[Def] | Spanned[Target]] = []
     err = Error("None", "nothing", None)
     while True:
         read = hd.peek()

--- a/v2beta/sylex_ast.py
+++ b/v2beta/sylex_ast.py
@@ -52,7 +52,7 @@ class Ident:
 
 @dataclass
 class DefList:
-    defs: Sequence[Spanned[Union[Def, Target]]]
+    defs: Sequence[Spanned[Def] | Spanned[Target]]
 
     def __str__(self) -> str:
         return "DefList {\n" + "\n".join(indent(f"{d}") for d in self.defs) + "\n}"

--- a/v2beta/sylex_ast.py
+++ b/v2beta/sylex_ast.py
@@ -1,54 +1,60 @@
-from enum import Enum
-from typing import TypeVar, Union, Optional, Sequence
 from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Sequence, TypeVar, Union
 
 T = TypeVar("T")
 U = TypeVar("U")
 
 from libparse import Loc, Span, Spanned
 
+
 def isname(c: str) -> bool:
-    return ('a' <= c <= 'z') or ('A' <= c <= 'Z') or (c in '_-.')
+    return ("a" <= c <= "z") or ("A" <= c <= "Z") or (c in "_-.")
+
 
 class Symbol(Enum):
-    DECLARE = '$'
-    OPENBRACE = '{'
-    CLOSEBRACE = '}'
-    OPENPAREN = '('
-    CLOSEPAREN = ')'
-    OPENBRACK = '['
-    CLOSEBRACK = ']'
-    EQUAL = '='
-    RIGHT = '->'
-    LEFT = '<-'
-    COMMA = ','
-    SEMI = ';'
-    SCOPE = '::'
-    COLON = ':'
+    DECLARE = "$"
+    OPENBRACE = "{"
+    CLOSEBRACE = "}"
+    OPENPAREN = "("
+    CLOSEPAREN = ")"
+    OPENBRACK = "["
+    CLOSEBRACK = "]"
+    EQUAL = "="
+    RIGHT = "->"
+    LEFT = "<-"
+    COMMA = ","
+    SEMI = ";"
+    SCOPE = "::"
+    COLON = ":"
+
 
 def indent(text: str) -> str:
-    return '\n'.join('    ' + line for line in text.split('\n'))
+    return "\n".join("    " + line for line in text.split("\n"))
+
 
 @dataclass
 class Ident:
     name: Spanned[str]
 
     @staticmethod
-    def concat(s: list[Spanned[str]]) -> 'Ident':
+    def concat(s: list[Spanned[str]]) -> "Ident":
         print(s)
-        string = ''.join(c.data for c in s)
+        string = "".join(c.data for c in s)
         span = Spanned.union(s)
         return Ident(span.with_data(string))
 
     def __str__(self) -> str:
         return f"Ident({self.name})"
 
+
 @dataclass
 class DefList:
-    defs: Sequence[Spanned[Union['Def', 'Target']]]
+    defs: Sequence[Spanned[Union["Def", "Target"]]]
 
     def __str__(self) -> str:
-        return "DefList {\n" + '\n'.join(indent(f"{d}") for d in self.defs) + "\n}"
+        return "DefList {\n" + "\n".join(indent(f"{d}") for d in self.defs) + "\n}"
+
 
 @dataclass
 class Target:
@@ -57,24 +63,29 @@ class Target:
     def __str__(self) -> str:
         return f"Target {self.name}"
 
+
 @dataclass
 class Def:
     name: Spanned[Ident]
-    value: Spanned['ItemList']
+    value: Spanned["ItemList"]
 
     def __str__(self) -> str:
         return f"Def {self.name} := " + self.value.__str__()
 
+
 @dataclass
 class ItemList:
-    items: Sequence[Spanned['Item']|Spanned['Expand']]
+    items: Sequence[Spanned["Item"] | Spanned["Expand"]]
 
     def __str__(self) -> str:
-        return "ItemList {\n" + '\n'.join(indent(i.__str__()) for i in self.items) + "\n}"
+        return (
+            "ItemList {\n" + "\n".join(indent(i.__str__()) for i in self.items) + "\n}"
+        )
+
 
 @dataclass
 class Item:
-    entry: Spanned['Entry']
+    entry: Spanned["Entry"]
     tail: Optional[Spanned[ItemList]]
 
     def __str__(self) -> str:
@@ -83,6 +94,7 @@ class Item:
         else:
             return f"Branch ({self.entry}) :: \n" + indent(self.tail.__str__())
 
+
 @dataclass
 class Expand:
     name: Spanned[Ident]
@@ -90,20 +102,22 @@ class Expand:
     def __str__(self) -> str:
         return f"Expand({self.name})"
 
-Tag = Union['Label', 'Induce', 'Depend']
+
+Tag = Union["Label", "Induce", "Depend"]
+
 
 @dataclass
 class Entry:
     name: Spanned[Ident]
-    labels: list[Spanned['Label']]
-    induce: list[Spanned['Induce']]
-    depend: list[Spanned['Depend']]
+    labels: list[Spanned["Label"]]
+    induce: list[Spanned["Induce"]]
+    depend: list[Spanned["Depend"]]
 
     @staticmethod
-    def from_name(name: Spanned[Ident]) -> 'Entry':
+    def from_name(name: Spanned[Ident]) -> "Entry":
         return Entry(name, [], [], [])
 
-    def push(self, mk: Spanned['Tag']) -> None:
+    def push(self, mk: Spanned["Tag"]) -> None:
         if isinstance(mk.data, Induce):
             self.induce.append(mk.span.with_data(mk.data))
         elif isinstance(mk.data, Label):
@@ -116,25 +130,27 @@ class Entry:
     def __str__(self) -> str:
         s = f"Entry({self.name})"
         for l in self.labels:
-            s += '\n' + indent(f"{l}")
+            s += "\n" + indent(f"{l}")
         for i in self.induce:
-            s += '\n' + indent(f"{i}")
+            s += "\n" + indent(f"{i}")
         for d in self.depend:
-            s += '\n' + indent(f"{d}")
+            s += "\n" + indent(f"{d}")
         return s
+
 
 @dataclass
 class Label:
     name: Spanned[Ident]
-    params: Spanned['Params']
+    params: Spanned["Params"]
 
     def __str__(self) -> str:
         return f"Label({self.name})\n  {self.params}"
 
+
 @dataclass
 class Induce:
     name: Spanned[Ident]
-    params: Spanned['Params']
+    params: Spanned["Params"]
 
     def __str__(self) -> str:
         return f"Induce({self.name})\n  {self.params}"
@@ -143,10 +159,11 @@ class Induce:
 @dataclass
 class Depend:
     name: Spanned[Ident]
-    params: Spanned['Params']
+    params: Spanned["Params"]
 
     def __str__(self) -> str:
         return f"Depend({self.name})\n  {self.params}"
+
 
 @dataclass
 class Params:
@@ -154,4 +171,3 @@ class Params:
 
     def __str__(self) -> str:
         return "Params(" + ",".join(f"{v}" for v in self.vals) + ")"
-

--- a/v2beta/sylex_ast.py
+++ b/v2beta/sylex_ast.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Sequence
 
-from libparse import Loc, Span, Spanned
+from libparse import Spanned
 
 
 def isname(c: str) -> bool:
@@ -26,6 +26,7 @@ class Symbol(Enum):
     SEMI = ";"
     SCOPE = "::"
     COLON = ":"
+    EOF = "\0"
 
 
 def indent(text: str) -> str:
@@ -49,6 +50,7 @@ class Ident:
 
 @dataclass
 class DefList:
+    # TODO: Use Sequence[Spanned[Def | Target]] instead
     defs: Sequence[Spanned[Def] | Spanned[Target]]
 
     def __str__(self) -> str:
@@ -74,7 +76,7 @@ class Def:
 
 @dataclass
 class ItemList:
-    items: Sequence[Spanned[Item] | Spanned[Expand]]
+    items: Sequence[Spanned[Item | Expand]]
 
     def __str__(self) -> str:
         return (

--- a/v2beta/sylex_ast.py
+++ b/v2beta/sylex_ast.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Sequence, TypeVar, Union
-
-T = TypeVar("T")
-U = TypeVar("U")
+from typing import Optional, Sequence
 
 from libparse import Loc, Span, Spanned
 
@@ -140,7 +137,7 @@ class Params:
         return "Params(" + ",".join(f"{v}" for v in self.vals) + ")"
 
 
-Tag = Union[Label, Induce, Depend]
+Tag = Label | Induce | Depend
 
 
 @dataclass


### PR DESCRIPTION
The following have been done in `v2beta` folder:
  - `black` formatter + `isort` applied.
  - `Wrong` wrapper removed.
  - `Union` new-Python syntax used.
  - Type hints improved.

Some block refactors have also been done, with "TODO" messages waiting for new `mypy` version.